### PR TITLE
[WL7-291] 할인 정책 조회 기능 구현

### DIFF
--- a/src/main/java/com/unear/pos/common/dto/PosSessionInfo.java
+++ b/src/main/java/com/unear/pos/common/dto/PosSessionInfo.java
@@ -1,5 +1,8 @@
 package com.unear.pos.common.dto;
 
+import com.unear.pos.common.dto.enums.EventParticipationStatus;
+import com.unear.pos.common.dto.enums.PlaceCategory;
+import com.unear.pos.common.dto.enums.PlaceType;
 import com.unear.pos.owner.entity.Owner;
 import com.unear.pos.place.entity.Place;
 import lombok.AllArgsConstructor;
@@ -16,9 +19,9 @@ public class PosSessionInfo {
     private String placeName;
     private String placeDesc;
     private String address;
-    private String markerCode;
-    private String eventTypeCode;
-    private String categoryCode;
+    private PlaceType placeType;
+    private EventParticipationStatus eventStatus;
+    private PlaceCategory placeCategory;
     private String benefitCategory;
     private String tel;
     private Integer startTime;
@@ -28,8 +31,9 @@ public class PosSessionInfo {
         return new PosSessionInfo(
                 owner.getOwnerId(), owner.getOwnerName(), owner.getPosId(),
                 place.getPlaceId(), place.getFranchiseId(), place.getPlaceName(),
-                place.getPlaceDesc(), place.getAddress(), place.getMarkerCode(),
-                place.getEventTypeCode(), place.getCategoryCode(),
+                place.getPlaceDesc(), place.getAddress(), PlaceType.valueOf(place.getMarkerCode()),
+                EventParticipationStatus.valueOf(place.getEventTypeCode()),
+                PlaceCategory.valueOf(place.getCategoryCode()),
                 place.getBenefitCategory(), place.getTel(), place.getStartTime(), place.getEndTime()
         );
     }

--- a/src/main/java/com/unear/pos/common/dto/enums/DiscountCode.java
+++ b/src/main/java/com/unear/pos/common/dto/enums/DiscountCode.java
@@ -1,0 +1,41 @@
+package com.unear.pos.common.dto.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DiscountCode {
+    MEMBERSHIP_UNIT("MEMBERSHIP_UNIT"),
+    MEMBERSHIP_FIXED("MEMBERSHIP_FIXED"),
+    COUPON_PERCENT("COUPON_PERCENT"),
+    COUPON_FIXED("COUPON_FIXED"),
+    COUPON_FCFS("COUPON_FCFS");
+
+
+    private final String code;
+
+    public boolean isMembership() {
+        return this == MEMBERSHIP_FIXED || this == MEMBERSHIP_UNIT;
+    }
+
+    public boolean isCoupon() {
+        return this == COUPON_PERCENT || this == COUPON_FIXED;
+    }
+
+    public boolean isMembershipUnit() {
+        return this == MEMBERSHIP_UNIT;
+    }
+
+    public boolean isMembershipFixed() {
+        return this == MEMBERSHIP_FIXED;
+    }
+
+    public boolean isCouponPercent() {
+        return this == COUPON_PERCENT;
+    }
+
+    public boolean isCouponFixed() {
+        return this == COUPON_FIXED;
+    }
+}

--- a/src/main/java/com/unear/pos/common/dto/enums/DiscountCode.java
+++ b/src/main/java/com/unear/pos/common/dto/enums/DiscountCode.java
@@ -20,7 +20,7 @@ public enum DiscountCode {
     }
 
     public boolean isCoupon() {
-        return this == COUPON_PERCENT || this == COUPON_FIXED;
+        return this == COUPON_PERCENT || this == COUPON_FIXED || this == COUPON_FCFS;
     }
 
     public boolean isMembershipUnit() {
@@ -37,5 +37,9 @@ public enum DiscountCode {
 
     public boolean isCouponFixed() {
         return this == COUPON_FIXED;
+    }
+
+    public boolean isCouponFcfs() {
+        return this == COUPON_FCFS;
     }
 }

--- a/src/main/java/com/unear/pos/common/dto/enums/DiscountTargetGrade.java
+++ b/src/main/java/com/unear/pos/common/dto/enums/DiscountTargetGrade.java
@@ -17,4 +17,8 @@ public enum DiscountTargetGrade {
     public static boolean isAll(String code) {
         return ALL.code.equalsIgnoreCase(code);
     }
+
+    public static DiscountTargetGrade fromMembershipGrade(MembershipGrade membershipGrade) {
+        return valueOf(membershipGrade.getCode());
+    }
 }

--- a/src/main/java/com/unear/pos/common/dto/enums/EventParticipationStatus.java
+++ b/src/main/java/com/unear/pos/common/dto/enums/EventParticipationStatus.java
@@ -1,0 +1,15 @@
+package com.unear.pos.common.dto.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventParticipationStatus {
+    NONE("NONE", "이벤트 미참여"),
+    GENERAL("GENERAL", "이벤트 참여(일반)"),
+    REQUIRE("REQUIRE", "이벤트 참여(필수)");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/unear/pos/common/dto/enums/PlaceCategory.java
+++ b/src/main/java/com/unear/pos/common/dto/enums/PlaceCategory.java
@@ -1,0 +1,21 @@
+package com.unear.pos.common.dto.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PlaceCategory {
+    FOOD("FOOD", "푸드"),
+    ACTIVITY("ACTIVITY", "액티비티"),
+    EDUCATION("EDUCATION", "교육"),
+    CULTURE("CULTURE", "문화/여가"),
+    BAKERY("BAKERY", "베이커리"),
+    LIFE("LIFE", "생활/편의"),
+    SHOPPING("SHOPPING", "쇼핑"),
+    CAFE("CAFE", "카페"),
+    BEAUTY("BEAUTY", "뷰티/건강");
+
+    private final String code;
+    private final String label;
+}

--- a/src/main/java/com/unear/pos/common/dto/enums/PlaceType.java
+++ b/src/main/java/com/unear/pos/common/dto/enums/PlaceType.java
@@ -1,0 +1,22 @@
+package com.unear.pos.common.dto.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PlaceType {
+    BASIC("BASIC"),
+    LOCAL("LOCAL"),
+    FRANCHISE("FRANCHISE");
+
+    private final String code;
+
+    public boolean isGeneralPolicy() {
+        return this == BASIC || this == LOCAL;
+    }
+
+    public boolean isFranchisePolicy() {
+        return this == FRANCHISE;
+    }
+}

--- a/src/main/java/com/unear/pos/discount/dto/DiscountPolicyInfo.java
+++ b/src/main/java/com/unear/pos/discount/dto/DiscountPolicyInfo.java
@@ -21,7 +21,6 @@ public class DiscountPolicyInfo {
     public static DiscountPolicyInfo from(GeneralDiscountPolicy policy) {
         return DiscountPolicyInfo.builder()
                 .discountCode(policy.getDiscountCode())
-                .discountCode(policy.getDiscountCode())
                 .unitBaseAmount(policy.getUnitBaseAmount())
                 .fixedDiscount(policy.getFixedDiscount())
                 .discountPercent(policy.getDiscountPercent())

--- a/src/main/java/com/unear/pos/discount/dto/DiscountPolicyInfo.java
+++ b/src/main/java/com/unear/pos/discount/dto/DiscountPolicyInfo.java
@@ -1,0 +1,45 @@
+package com.unear.pos.discount.dto;
+
+import com.unear.pos.discount.entity.FranchiseDiscountPolicy;
+import com.unear.pos.discount.entity.GeneralDiscountPolicy;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiscountPolicyInfo {
+    private String discountCode;
+    private Integer unitBaseAmount;
+    private Integer fixedDiscount;
+    private Integer discountPercent;
+    private Integer minPurchaseAmount;
+    private Integer maxDiscountAmount;
+    private String membershipCode;
+
+    public static DiscountPolicyInfo from(GeneralDiscountPolicy policy) {
+        return DiscountPolicyInfo.builder()
+                .discountCode(policy.getDiscountCode())
+                .discountCode(policy.getDiscountCode())
+                .unitBaseAmount(policy.getUnitBaseAmount())
+                .fixedDiscount(policy.getFixedDiscount())
+                .discountPercent(policy.getDiscountPercent())
+                .minPurchaseAmount(policy.getMinPurchaseAmount())
+                .maxDiscountAmount(policy.getMaxDiscountAmount())
+                .membershipCode(policy.getMembershipCode())
+                .build();
+    }
+
+    public static DiscountPolicyInfo from(FranchiseDiscountPolicy policy) {
+        return DiscountPolicyInfo.builder()
+                .discountCode(policy.getDiscountCode())
+                .unitBaseAmount(policy.getUnitBaseAmount())
+                .fixedDiscount(policy.getFixedDiscount())
+                .discountPercent(policy.getDiscountPercent())
+                .minPurchaseAmount(policy.getMinPurchaseAmount())
+                .maxDiscountAmount(policy.getMaxDiscountAmount())
+                .membershipCode(policy.getMembershipCode())
+                .build();
+    }
+}

--- a/src/main/java/com/unear/pos/discount/entity/FranchiseDiscountPolicy.java
+++ b/src/main/java/com/unear/pos/discount/entity/FranchiseDiscountPolicy.java
@@ -1,0 +1,42 @@
+package com.unear.pos.discount.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "franchise_discount_policy")
+@Getter
+@NoArgsConstructor
+public class FranchiseDiscountPolicy {
+    @Id
+    @Column(name = "franchise_discount_policy_id")
+    private Long id;
+
+    @Column(name = "franchise_id")
+    private Long franchiseId;
+
+    @Column(name = "membership_code")
+    private String membershipCode;
+
+    @Column(name = "discount_code")
+    private String discountCode;
+
+    @Column(name = "unit_base_amount")
+    private Integer unitBaseAmount;
+
+    @Column(name = "fixed_discount")
+    private Integer fixedDiscount;
+
+    @Column(name = "discount_percent")
+    private Integer discountPercent;
+
+    @Column(name = "min_purchase_amount")
+    private Integer minPurchaseAmount;
+
+    @Column(name = "max_discount_amount")
+    private Integer maxDiscountAmount;
+}

--- a/src/main/java/com/unear/pos/discount/entity/GeneralDiscountPolicy.java
+++ b/src/main/java/com/unear/pos/discount/entity/GeneralDiscountPolicy.java
@@ -1,0 +1,46 @@
+package com.unear.pos.discount.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "general_discount_policy")
+@Getter
+@NoArgsConstructor
+public class GeneralDiscountPolicy {
+
+    @Id
+    @Column(name = "general_discount_policy_id")
+    private Long id;
+
+    @Column(name = "place_id")
+    private Long placeId;
+
+    @Column(name = "membership_code")
+    private String membershipCode;
+
+    @Column(name = "discount_code")
+    private String discountCode;
+
+    @Column(name = "unit_base_amount")
+    private Integer unitBaseAmount;
+
+    @Column(name = "fixed_discount")
+    private Integer fixedDiscount;
+
+    @Column(name = "discount_percent")
+    private Integer discountPercent;
+
+    @Column(name = "min_purchase_amount")
+    private Integer minPurchaseAmount;
+
+    @Column(name = "max_discount_amount")
+    private Integer maxDiscountAmount;
+
+    @Column(name = "marker_code")
+    private String markerCode;
+}

--- a/src/main/java/com/unear/pos/discount/repository/FranchiseDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/pos/discount/repository/FranchiseDiscountPolicyRepository.java
@@ -1,0 +1,9 @@
+package com.unear.pos.discount.repository;
+
+import com.unear.pos.discount.entity.FranchiseDiscountPolicy;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FranchiseDiscountPolicyRepository extends JpaRepository<FranchiseDiscountPolicy, Long> {
+    List<FranchiseDiscountPolicy> findByFranchiseIdAndMembershipCode(Long franchiseId, String code);
+}

--- a/src/main/java/com/unear/pos/discount/repository/GeneralDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/pos/discount/repository/GeneralDiscountPolicyRepository.java
@@ -1,0 +1,9 @@
+package com.unear.pos.discount.repository;
+
+import com.unear.pos.discount.entity.GeneralDiscountPolicy;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GeneralDiscountPolicyRepository extends JpaRepository<GeneralDiscountPolicy, Long> {
+    List<GeneralDiscountPolicy> findByPlaceIdAndMembershipCode(Long placeId, String code);
+}

--- a/src/main/java/com/unear/pos/discount/service/DiscountService.java
+++ b/src/main/java/com/unear/pos/discount/service/DiscountService.java
@@ -1,0 +1,11 @@
+package com.unear.pos.discount.service;
+
+import com.unear.pos.common.dto.PosSessionInfo;
+import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import java.util.List;
+
+public interface DiscountService {
+    List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, PosSessionInfo posInfo);
+
+}

--- a/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
+++ b/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
@@ -1,0 +1,48 @@
+package com.unear.pos.discount.service.impl;
+
+import com.unear.pos.common.dto.PosSessionInfo;
+import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.common.dto.enums.PlaceType;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.service.DiscountService;
+import com.unear.pos.discount.strategy.DiscountPolicyStrategy;
+import com.unear.pos.discount.strategy.FranchiseDiscountPolicyStrategy;
+import com.unear.pos.discount.strategy.GeneralDiscountPolicyStrategy;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class DiscountServiceImpl implements DiscountService {
+
+    private final GeneralDiscountPolicyStrategy generalStrategy;
+    private final FranchiseDiscountPolicyStrategy franchiseStrategy;
+
+    @Override
+    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, PosSessionInfo posInfo) {
+        DiscountPolicyStrategy strategy = selectStrategy(posInfo.getPlaceType());
+        Long targetId = getTargetId(posInfo, posInfo.getPlaceType());
+
+        return strategy.getDiscountPolicies(memberGrade, targetId, posInfo.getEventStatus());
+    }
+
+    private DiscountPolicyStrategy selectStrategy(PlaceType placeType) {
+        if (placeType.isGeneralPolicy()) {
+            return generalStrategy;
+        } else if (placeType.isFranchisePolicy()) {
+            return franchiseStrategy;
+        }
+        throw new IllegalArgumentException("지원하지 않는 장소 타입: " + placeType);
+
+    }
+
+    private Long getTargetId(PosSessionInfo posInfo, PlaceType placeType) {
+        if (placeType.isGeneralPolicy()) {
+            return posInfo.getPlaceId();
+        } else if (placeType.isFranchisePolicy()) {
+            return posInfo.getFranchiseId();
+        }
+        throw new IllegalArgumentException("지원하지 않는 장소 타입: " + placeType);
+    }
+}

--- a/src/main/java/com/unear/pos/discount/strategy/DiscountPolicyStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/DiscountPolicyStrategy.java
@@ -1,0 +1,11 @@
+package com.unear.pos.discount.strategy;
+
+import com.unear.pos.common.dto.enums.EventParticipationStatus;
+import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import java.util.List;
+
+public interface DiscountPolicyStrategy {
+    List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long targetId,
+                                                 EventParticipationStatus eventStatus);
+}

--- a/src/main/java/com/unear/pos/discount/strategy/FranchiseDiscountPolicyStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/FranchiseDiscountPolicyStrategy.java
@@ -1,0 +1,38 @@
+package com.unear.pos.discount.strategy;
+
+import com.unear.pos.common.dto.enums.DiscountCode;
+import com.unear.pos.common.dto.enums.DiscountTargetGrade;
+import com.unear.pos.common.dto.enums.EventParticipationStatus;
+import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.entity.FranchiseDiscountPolicy;
+import com.unear.pos.discount.repository.FranchiseDiscountPolicyRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class FranchiseDiscountPolicyStrategy implements DiscountPolicyStrategy {
+
+    private final FranchiseDiscountPolicyRepository repository;
+
+    @Override
+    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long franchiseId,
+                                                        EventParticipationStatus eventStatus) {
+
+        List<FranchiseDiscountPolicy> allGradePolicies = repository.findByFranchiseIdAndMembershipCode(franchiseId,
+                DiscountTargetGrade.ALL.getCode());
+
+        DiscountTargetGrade targetGrade = DiscountTargetGrade.fromMembershipGrade(memberGrade);
+        List<FranchiseDiscountPolicy> specificGradePolicies = repository.findByFranchiseIdAndMembershipCode(franchiseId,
+                targetGrade.getCode());
+
+        return Stream.concat(allGradePolicies.stream(), specificGradePolicies.stream())
+                .filter(policy -> DiscountCode.valueOf(policy.getDiscountCode()).isMembership())
+                .map(DiscountPolicyInfo::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/unear/pos/discount/strategy/GeneralDiscountPolicyStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/GeneralDiscountPolicyStrategy.java
@@ -1,0 +1,44 @@
+package com.unear.pos.discount.strategy;
+
+import com.unear.pos.common.dto.enums.DiscountCode;
+import com.unear.pos.common.dto.enums.DiscountTargetGrade;
+import com.unear.pos.common.dto.enums.EventParticipationStatus;
+import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.entity.GeneralDiscountPolicy;
+import com.unear.pos.discount.repository.GeneralDiscountPolicyRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GeneralDiscountPolicyStrategy implements DiscountPolicyStrategy {
+
+    private final GeneralDiscountPolicyRepository repository;
+
+    @Override
+    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long placeId,
+                                                        EventParticipationStatus eventStatus) {
+        /**
+         * 1. 전체 등급이 적용 가능한 쿠폰이 존재하는지 조회
+         */
+        List<GeneralDiscountPolicy> allGradePolicies = repository.findByPlaceIdAndMembershipCode(placeId,
+                DiscountTargetGrade.ALL.getCode());
+
+        /**
+         * 2. 특정 등급 정책 조회
+         */
+        DiscountTargetGrade targetGrade = DiscountTargetGrade.fromMembershipGrade(memberGrade);
+        List<GeneralDiscountPolicy> specificGradePolicies = repository.findByPlaceIdAndMembershipCode(placeId,
+                targetGrade.getCode());
+
+        return Stream.concat(allGradePolicies.stream(), specificGradePolicies.stream())
+                .filter(policy -> DiscountCode.valueOf(policy.getDiscountCode()).isMembership())
+                .map(DiscountPolicyInfo::from)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/unear/pos/member/dto/MemberInfo.java
+++ b/src/main/java/com/unear/pos/member/dto/MemberInfo.java
@@ -1,7 +1,10 @@
 package com.unear.pos.member.dto;
 
 import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
 import com.unear.pos.member.entity.Member;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,13 +16,19 @@ public class MemberInfo {
     private Long memberId;
     private String memberName;
     private MembershipGrade memberGrade;
+    private List<DiscountPolicyInfo> discountPolicies;
 
     public static MemberInfo from(Member member) {
         return MemberInfo.builder()
                 .memberId(member.getUserId())
                 .memberName(maskName(member.getName()))
                 .memberGrade(MembershipGrade.fromCode(member.getMembershipCode()))
+                .discountPolicies(new ArrayList<>())
                 .build();
+    }
+
+    public MemberInfo withDiscountPolicies(List<DiscountPolicyInfo> policies) {
+        return new MemberInfo(this.memberId, this.memberName, this.memberGrade, policies);
     }
 
     private static String maskName(String name) {

--- a/src/main/java/com/unear/pos/membership/controller/MembershipController.java
+++ b/src/main/java/com/unear/pos/membership/controller/MembershipController.java
@@ -28,7 +28,7 @@ public class MembershipController {
             @Valid @RequestBody MemberVerifyRequestDto request,
             @CurrentPosSession PosSessionInfo posInfo) {
 
-        MemberInfo memberInfo = membershipService.verifyMember(request);
+        MemberInfo memberInfo = membershipService.verifyMember(request, posInfo);
         return ResponseEntity.ok(ApiResponse.success("회원 인증 완료", memberInfo));
     }
 }

--- a/src/main/java/com/unear/pos/membership/service/MembershipService.java
+++ b/src/main/java/com/unear/pos/membership/service/MembershipService.java
@@ -1,8 +1,9 @@
 package com.unear.pos.membership.service;
 
+import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.member.dto.MemberInfo;
 import com.unear.pos.membership.dto.MemberVerifyRequestDto;
 
 public interface MembershipService {
-    MemberInfo verifyMember(MemberVerifyRequestDto request);
+    MemberInfo verifyMember(MemberVerifyRequestDto request, PosSessionInfo posInfo);
 }

--- a/src/main/java/com/unear/pos/membership/service/impl/MembershipServiceImpl.java
+++ b/src/main/java/com/unear/pos/membership/service/impl/MembershipServiceImpl.java
@@ -1,12 +1,16 @@
 package com.unear.pos.membership.service.impl;
 
+import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.common.dto.enums.VerificationType;
 import com.unear.pos.common.exception.business.MemberNotFoundException;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.service.DiscountService;
 import com.unear.pos.member.dto.MemberInfo;
 import com.unear.pos.member.entity.Member;
 import com.unear.pos.membership.dto.MemberVerifyRequestDto;
 import com.unear.pos.membership.repository.MemberRepository;
 import com.unear.pos.membership.service.MembershipService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,10 +19,11 @@ import org.springframework.stereotype.Service;
 public class MembershipServiceImpl implements MembershipService {
 
     private final MemberRepository memberRepository;
+    private final DiscountService discountService;
 
 
     @Override
-    public MemberInfo verifyMember(MemberVerifyRequestDto request) {
+    public MemberInfo verifyMember(MemberVerifyRequestDto request, PosSessionInfo posInfo) {
         VerificationType type = VerificationType.fromString(request.getType());
 
         Member member = switch (type) {
@@ -26,7 +31,11 @@ public class MembershipServiceImpl implements MembershipService {
             case PHONE -> findByPhone(request.getValue());
         };
 
-        return MemberInfo.from(member);
+        MemberInfo memberInfo = MemberInfo.from(member);
+
+        List<DiscountPolicyInfo> policies = discountService.getDiscountPolicies(memberInfo.getMemberGrade(), posInfo);
+
+        return memberInfo.withDiscountPolicies(policies);
     }
 
     private Member findByPhone(String value) {


### PR DESCRIPTION
## PR 목적
회원 인증 시 적용 가능한 할인 정책을 자동 조회하여 POS 결제 프로세스에서 즉시 혜택을 확인할 수 있도록 기능 추가


## 변경 사항

- 할인 정책 조회 API 추가 (회원 인증과 통합)
- 전략 패턴 기반 할인 정책 서비스 구현
- Enum 타입 추가 및 PosSessionInfo 타입 안전성 강화



## 주요 구현 내용

- DiscountPolicyStrategy 인터페이스로 General/Franchise 정책 분리
- MembershipService.verifyMember() 할인 정책 자동 조회 로직 추가
- PlaceType, DiscountCode 등 5개 Enum 추가로 하드코딩 제거
- PosSessionInfo String 필드 → Enum 변환으로 타입 안전성 확보
- 멤버십 할인만 필터링 (쿠폰 할인 제외)



## 테스트 및 동작 화면 (필요 시 첨부)

```shell
 curl -X POST http://localhost:8080/membership/verify \
  -H "Content-Type: application/json" \
  -b cookies.txt \
  -d '{
    "type": "barcode",
    "value": "6634488a32174f68"
  }'
{"status":200,"code":"SUCCESS","message":"회원 인증 완료","data":{"memberId":13,"memberName":"테****자","memberGrade":"VIP","discountPolicies":[{"discountCode":"MEMBERSHIP_UNIT","unitBaseAmount":100,"fixedDiscount":null,"discountPercent":null,"minPurchaseAmount":null,"maxDiscountAmount":null,"membershipCode":"VIP"}]}}%
```

## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
