### PR TITLE
[WL7-377] 할인 적용 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
     mavenCentral()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
@@ -35,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/unear/pos/common/dto/MemberSession.java
+++ b/src/main/java/com/unear/pos/common/dto/MemberSession.java
@@ -1,0 +1,24 @@
+package com.unear.pos.common.dto;
+
+import com.unear.pos.common.dto.enums.MembershipGrade;
+import com.unear.pos.member.dto.MemberInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSession {
+    private Long memberId;
+    private MembershipGrade memberGrade;
+    private Long placeId;
+    private String memberName;
+
+    public static MemberSession from(MemberInfo memberInfo, PosSessionInfo posInfo) {
+        return new MemberSession(
+                memberInfo.getMemberId(),
+                memberInfo.getMemberGrade(),
+                posInfo.getPlaceId(),
+                memberInfo.getMemberName()
+        );
+    }
+}

--- a/src/main/java/com/unear/pos/common/dto/Money.java
+++ b/src/main/java/com/unear/pos/common/dto/Money.java
@@ -1,6 +1,7 @@
 package com.unear.pos.common.dto;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -39,5 +40,27 @@ public class Money {
 
     public boolean isLessThan(Money other) {
         return this.amount.compareTo(other.amount) < 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Money money = (Money) obj;
+        return this.amount.compareTo(money.amount) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount.stripTrailingZeros());
+    }
+
+    @Override
+    public String toString() {
+        return "Money{amount=" + amount + "}";
     }
 }

--- a/src/main/java/com/unear/pos/common/dto/Money.java
+++ b/src/main/java/com/unear/pos/common/dto/Money.java
@@ -11,6 +11,9 @@ public class Money {
     private final BigDecimal amount;
 
     public static Money of(BigDecimal amount) {
+        if (amount == null) {
+            throw new IllegalArgumentException("금액은 null일 수 없습니다");
+        }
         return new Money(amount);
     }
 

--- a/src/main/java/com/unear/pos/common/dto/Money.java
+++ b/src/main/java/com/unear/pos/common/dto/Money.java
@@ -1,0 +1,43 @@
+package com.unear.pos.common.dto;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Money {
+    private final BigDecimal amount;
+
+    public static Money of(BigDecimal amount) {
+        return new Money(amount);
+    }
+
+    public static Money of(long amount) {
+        return new Money(BigDecimal.valueOf(amount));
+    }
+
+    public static Money zero() {
+        return new Money(BigDecimal.ZERO);
+    }
+
+    public Money add(Money other) {
+        return new Money(this.amount.add(other.amount));
+    }
+
+    public Money subtract(Money other) {
+        return new Money(this.amount.subtract(other.amount));
+    }
+
+    public Money multiply(BigDecimal multiplier) {
+        return new Money(this.amount.multiply(multiplier));
+    }
+
+    public boolean isGreaterThan(Money other) {
+        return this.amount.compareTo(other.amount) > 0;
+    }
+
+    public boolean isLessThan(Money other) {
+        return this.amount.compareTo(other.amount) < 0;
+    }
+}

--- a/src/main/java/com/unear/pos/discount/controller/DiscountController.java
+++ b/src/main/java/com/unear/pos/discount/controller/DiscountController.java
@@ -1,0 +1,36 @@
+package com.unear.pos.discount.controller;
+
+import com.unear.pos.common.dto.PosSessionInfo;
+import com.unear.pos.common.resolver.CurrentPosSession;
+import com.unear.pos.common.response.ApiResponse;
+import com.unear.pos.discount.dto.request.DiscountApplyRequestDto;
+import com.unear.pos.discount.dto.response.DiscountApplyResponseDto;
+import com.unear.pos.discount.service.DiscountService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/discount")
+@RequiredArgsConstructor
+public class DiscountController {
+
+    private final DiscountService discountService;
+
+    @PostMapping("/apply")
+    public ResponseEntity<ApiResponse<DiscountApplyResponseDto>> applyDiscount(
+            @Valid @RequestBody DiscountApplyRequestDto request,
+            @CurrentPosSession PosSessionInfo posInfo,
+            HttpSession session) {
+
+        DiscountApplyResponseDto response = discountService.applyDiscount(
+                request, posInfo, session);
+
+        return ResponseEntity.ok(ApiResponse.success("할인 적용 완료", response));
+    }
+}

--- a/src/main/java/com/unear/pos/discount/dto/DiscountPolicyInfo.java
+++ b/src/main/java/com/unear/pos/discount/dto/DiscountPolicyInfo.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class DiscountPolicyInfo {
+    private Long id;
     private String discountCode;
     private Integer unitBaseAmount;
     private Integer fixedDiscount;
@@ -20,6 +21,7 @@ public class DiscountPolicyInfo {
 
     public static DiscountPolicyInfo from(GeneralDiscountPolicy policy) {
         return DiscountPolicyInfo.builder()
+                .id(policy.getId())
                 .discountCode(policy.getDiscountCode())
                 .unitBaseAmount(policy.getUnitBaseAmount())
                 .fixedDiscount(policy.getFixedDiscount())
@@ -32,6 +34,7 @@ public class DiscountPolicyInfo {
 
     public static DiscountPolicyInfo from(FranchiseDiscountPolicy policy) {
         return DiscountPolicyInfo.builder()
+                .id(policy.getId())
                 .discountCode(policy.getDiscountCode())
                 .unitBaseAmount(policy.getUnitBaseAmount())
                 .fixedDiscount(policy.getFixedDiscount())

--- a/src/main/java/com/unear/pos/discount/dto/request/DiscountApplyRequestDto.java
+++ b/src/main/java/com/unear/pos/discount/dto/request/DiscountApplyRequestDto.java
@@ -1,0 +1,17 @@
+package com.unear.pos.discount.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DiscountApplyRequestDto {
+    @NotNull(message = "할인 정책 ID는 필수입니다")
+    private Long discountPolicyId;
+
+    @NotNull(message = "구매 금액은 필수입니다")
+    @Min(value = 0, message = "구매 금액은 0 이상이어야 합니다")
+    private Long purchaseAmount;
+}

--- a/src/main/java/com/unear/pos/discount/dto/response/DiscountApplyResponseDto.java
+++ b/src/main/java/com/unear/pos/discount/dto/response/DiscountApplyResponseDto.java
@@ -1,0 +1,14 @@
+package com.unear.pos.discount.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiscountApplyResponseDto {
+    private String discountCode;
+    private Long discountAmount;
+    private Long finalAmount;
+}

--- a/src/main/java/com/unear/pos/discount/service/DiscountCalculationService.java
+++ b/src/main/java/com/unear/pos/discount/service/DiscountCalculationService.java
@@ -1,0 +1,8 @@
+package com.unear.pos.discount.service;
+
+import com.unear.pos.common.dto.Money;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+
+public interface DiscountCalculationService {
+    Money calculateDiscount(Money purchaseAmount, DiscountPolicyInfo policy);
+}

--- a/src/main/java/com/unear/pos/discount/service/DiscountService.java
+++ b/src/main/java/com/unear/pos/discount/service/DiscountService.java
@@ -3,9 +3,15 @@ package com.unear.pos.discount.service;
 import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.common.dto.enums.MembershipGrade;
 import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.dto.request.DiscountApplyRequestDto;
+import com.unear.pos.discount.dto.response.DiscountApplyResponseDto;
+import jakarta.servlet.http.HttpSession;
 import java.util.List;
 
 public interface DiscountService {
     List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, PosSessionInfo posInfo);
+
+    DiscountApplyResponseDto applyDiscount(DiscountApplyRequestDto request, PosSessionInfo posInfo,
+                                           HttpSession session);
 
 }

--- a/src/main/java/com/unear/pos/discount/service/impl/DiscountCalculationServiceImpl.java
+++ b/src/main/java/com/unear/pos/discount/service/impl/DiscountCalculationServiceImpl.java
@@ -1,0 +1,35 @@
+package com.unear.pos.discount.service.impl;
+
+import com.unear.pos.common.dto.Money;
+import com.unear.pos.common.dto.enums.DiscountCode;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.service.DiscountCalculationService;
+import com.unear.pos.discount.strategy.calculator.DiscountCalculationStrategy;
+import com.unear.pos.discount.strategy.calculator.MembershipFixedDiscountStrategy;
+import com.unear.pos.discount.strategy.calculator.MembershipUnitDiscountStrategy;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class DiscountCalculationServiceImpl implements DiscountCalculationService {
+
+    private final MembershipUnitDiscountStrategy membershipUnitStrategy;
+    private final MembershipFixedDiscountStrategy membershipFixedStrategy;
+
+    @Override
+    public Money calculateDiscount(Money purchaseAmount, DiscountPolicyInfo policy) {
+        DiscountCode discountCode = DiscountCode.valueOf(policy.getDiscountCode());
+
+        DiscountCalculationStrategy strategy = selectStrategy(discountCode);
+        return strategy.calculateDiscount(purchaseAmount, policy);
+    }
+
+    private DiscountCalculationStrategy selectStrategy(DiscountCode discountCode) {
+        return switch (discountCode) {
+            case MEMBERSHIP_UNIT -> membershipUnitStrategy;
+            case MEMBERSHIP_FIXED -> membershipFixedStrategy;
+            default -> throw new IllegalArgumentException("지원하지 않는 할인 코드: " + discountCode);
+        };
+    }
+}

--- a/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
+++ b/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
@@ -1,13 +1,19 @@
 package com.unear.pos.discount.service.impl;
 
+import com.unear.pos.common.dto.MemberSession;
+import com.unear.pos.common.dto.Money;
 import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.common.dto.enums.MembershipGrade;
 import com.unear.pos.common.dto.enums.PlaceType;
 import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import com.unear.pos.discount.dto.request.DiscountApplyRequestDto;
+import com.unear.pos.discount.dto.response.DiscountApplyResponseDto;
+import com.unear.pos.discount.service.DiscountCalculationService;
 import com.unear.pos.discount.service.DiscountService;
-import com.unear.pos.discount.strategy.DiscountPolicyStrategy;
-import com.unear.pos.discount.strategy.FranchiseDiscountPolicyStrategy;
-import com.unear.pos.discount.strategy.GeneralDiscountPolicyStrategy;
+import com.unear.pos.discount.strategy.provider.DiscountPolicyStrategy;
+import com.unear.pos.discount.strategy.provider.FranchiseDiscountPolicyStrategy;
+import com.unear.pos.discount.strategy.provider.GeneralDiscountPolicyStrategy;
+import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +24,7 @@ public class DiscountServiceImpl implements DiscountService {
 
     private final GeneralDiscountPolicyStrategy generalStrategy;
     private final FranchiseDiscountPolicyStrategy franchiseStrategy;
+    private final DiscountCalculationService discountCalculationService;
 
     @Override
     public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, PosSessionInfo posInfo) {
@@ -25,6 +32,36 @@ public class DiscountServiceImpl implements DiscountService {
         Long targetId = getTargetId(posInfo, posInfo.getPlaceType());
 
         return strategy.getDiscountPolicies(memberGrade, targetId, posInfo.getEventStatus());
+    }
+
+    @Override
+    public DiscountApplyResponseDto applyDiscount(DiscountApplyRequestDto request, PosSessionInfo posInfo,
+                                                  HttpSession session) {
+
+        MemberSession memberSession = (MemberSession) session.getAttribute("memberSession");
+        if (memberSession == null) {
+            throw new IllegalStateException("회원 인증이 필요합니다");
+        }
+
+        MembershipGrade memberGrade = memberSession.getMemberGrade();
+
+        List<DiscountPolicyInfo> availablePolicies = getDiscountPolicies(memberGrade, posInfo);
+
+        DiscountPolicyInfo selectedPolicy = availablePolicies.stream()
+                .filter(policy -> policy.getId().equals(request.getDiscountPolicyId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("적용할 수 없는 할인 정책입니다"));
+
+        Money purchaseAmount = Money.of(request.getPurchaseAmount());
+        Money discountAmount = discountCalculationService.calculateDiscount(purchaseAmount, selectedPolicy);
+        Money finalAmount = purchaseAmount.subtract(discountAmount);
+
+        return DiscountApplyResponseDto.builder()
+                .discountCode(selectedPolicy.getDiscountCode())
+                .discountAmount(discountAmount.getAmount().longValue())
+                .finalAmount(finalAmount.getAmount().longValue())
+                .build();
+
     }
 
     private DiscountPolicyStrategy selectStrategy(PlaceType placeType) {

--- a/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
+++ b/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
@@ -53,6 +53,10 @@ public class DiscountServiceImpl implements DiscountService {
                 .orElseThrow(() -> new IllegalArgumentException("적용할 수 없는 할인 정책입니다"));
 
         Money purchaseAmount = Money.of(request.getPurchaseAmount());
+        if (purchaseAmount.isLessThan(Money.zero()) || purchaseAmount.equals(Money.zero())) {
+            throw new IllegalArgumentException("구매 금액은 0보다 커야합니다.");
+        }
+
         Money discountAmount = discountCalculationService.calculateDiscount(purchaseAmount, selectedPolicy);
         Money finalAmount = purchaseAmount.subtract(discountAmount);
 

--- a/src/main/java/com/unear/pos/discount/strategy/calculator/DiscountCalculationStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/calculator/DiscountCalculationStrategy.java
@@ -1,0 +1,8 @@
+package com.unear.pos.discount.strategy.calculator;
+
+import com.unear.pos.common.dto.Money;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+
+public interface DiscountCalculationStrategy {
+    Money calculateDiscount(Money purchaseAmount, DiscountPolicyInfo policy);
+}

--- a/src/main/java/com/unear/pos/discount/strategy/calculator/MembershipFixedDiscountStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/calculator/MembershipFixedDiscountStrategy.java
@@ -1,0 +1,30 @@
+package com.unear.pos.discount.strategy.calculator;
+
+import com.unear.pos.common.dto.Money;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MembershipFixedDiscountStrategy implements DiscountCalculationStrategy {
+    @Override
+    public Money calculateDiscount(Money purchaseAmount, DiscountPolicyInfo policy) {
+        if (policy.getFixedDiscount() == null) {
+            return Money.zero();
+        }
+
+        if (policy.getMinPurchaseAmount() != null) {
+            Money minAmount = Money.of(policy.getMinPurchaseAmount());
+            if (purchaseAmount.isLessThan(minAmount)) {
+                return Money.zero();
+            }
+        }
+
+        Money discount = Money.of(policy.getFixedDiscount());
+
+        if (discount.isGreaterThan(purchaseAmount)) {
+            return purchaseAmount;
+        }
+
+        return discount;
+    }
+}

--- a/src/main/java/com/unear/pos/discount/strategy/calculator/MembershipUnitDiscountStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/calculator/MembershipUnitDiscountStrategy.java
@@ -1,0 +1,40 @@
+package com.unear.pos.discount.strategy.calculator;
+
+import com.unear.pos.common.dto.Money;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MembershipUnitDiscountStrategy implements DiscountCalculationStrategy {
+
+    private static final BigDecimal DISCOUNT_BASE_UNIT = BigDecimal.valueOf(1000); // 1000원 단위
+
+    @Override
+    public Money calculateDiscount(Money purchaseAmount, DiscountPolicyInfo policy) {
+        if (policy.getUnitBaseAmount() == null) {
+            return Money.zero();
+        }
+
+        if (policy.getMinPurchaseAmount() != null) {
+            Money minAmount = Money.of(policy.getMinPurchaseAmount());
+            if (purchaseAmount.isLessThan(minAmount)) {
+                return Money.zero();
+            }
+        }
+
+        BigDecimal discountUnits = purchaseAmount.getAmount().divide(DISCOUNT_BASE_UNIT, 0, RoundingMode.DOWN);
+        Money discount = Money.of(discountUnits.multiply(BigDecimal.valueOf(policy.getUnitBaseAmount())));
+
+        if (policy.getMaxDiscountAmount() != null) {
+            Money maxDiscount = Money.of(policy.getMaxDiscountAmount());
+
+            if (discount.isGreaterThan(maxDiscount)) {
+                return maxDiscount;
+            }
+        }
+
+        return discount;
+    }
+}

--- a/src/main/java/com/unear/pos/discount/strategy/provider/DiscountPolicyStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/provider/DiscountPolicyStrategy.java
@@ -1,4 +1,4 @@
-package com.unear.pos.discount.strategy;
+package com.unear.pos.discount.strategy.provider;
 
 import com.unear.pos.common.dto.enums.EventParticipationStatus;
 import com.unear.pos.common.dto.enums.MembershipGrade;

--- a/src/main/java/com/unear/pos/discount/strategy/provider/FranchiseDiscountPolicyStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/provider/FranchiseDiscountPolicyStrategy.java
@@ -1,38 +1,33 @@
-package com.unear.pos.discount.strategy;
+package com.unear.pos.discount.strategy.provider;
 
 import com.unear.pos.common.dto.enums.DiscountCode;
 import com.unear.pos.common.dto.enums.DiscountTargetGrade;
 import com.unear.pos.common.dto.enums.EventParticipationStatus;
 import com.unear.pos.common.dto.enums.MembershipGrade;
 import com.unear.pos.discount.dto.DiscountPolicyInfo;
-import com.unear.pos.discount.entity.GeneralDiscountPolicy;
-import com.unear.pos.discount.repository.GeneralDiscountPolicyRepository;
+import com.unear.pos.discount.entity.FranchiseDiscountPolicy;
+import com.unear.pos.discount.repository.FranchiseDiscountPolicyRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
-public class GeneralDiscountPolicyStrategy implements DiscountPolicyStrategy {
+@AllArgsConstructor
+public class FranchiseDiscountPolicyStrategy implements DiscountPolicyStrategy {
 
-    private final GeneralDiscountPolicyRepository repository;
+    private final FranchiseDiscountPolicyRepository repository;
 
     @Override
-    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long placeId,
+    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long franchiseId,
                                                         EventParticipationStatus eventStatus) {
-        /**
-         * 1. 전체 등급이 적용 가능한 쿠폰이 존재하는지 조회
-         */
-        List<GeneralDiscountPolicy> allGradePolicies = repository.findByPlaceIdAndMembershipCode(placeId,
+
+        List<FranchiseDiscountPolicy> allGradePolicies = repository.findByFranchiseIdAndMembershipCode(franchiseId,
                 DiscountTargetGrade.ALL.getCode());
 
-        /**
-         * 2. 특정 등급 정책 조회
-         */
         DiscountTargetGrade targetGrade = DiscountTargetGrade.fromMembershipGrade(memberGrade);
-        List<GeneralDiscountPolicy> specificGradePolicies = repository.findByPlaceIdAndMembershipCode(placeId,
+        List<FranchiseDiscountPolicy> specificGradePolicies = repository.findByFranchiseIdAndMembershipCode(franchiseId,
                 targetGrade.getCode());
 
         return Stream.concat(allGradePolicies.stream(), specificGradePolicies.stream())
@@ -40,5 +35,4 @@ public class GeneralDiscountPolicyStrategy implements DiscountPolicyStrategy {
                 .map(DiscountPolicyInfo::from)
                 .collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/com/unear/pos/discount/strategy/provider/GeneralDiscountPolicyStrategy.java
+++ b/src/main/java/com/unear/pos/discount/strategy/provider/GeneralDiscountPolicyStrategy.java
@@ -1,33 +1,38 @@
-package com.unear.pos.discount.strategy;
+package com.unear.pos.discount.strategy.provider;
 
 import com.unear.pos.common.dto.enums.DiscountCode;
 import com.unear.pos.common.dto.enums.DiscountTargetGrade;
 import com.unear.pos.common.dto.enums.EventParticipationStatus;
 import com.unear.pos.common.dto.enums.MembershipGrade;
 import com.unear.pos.discount.dto.DiscountPolicyInfo;
-import com.unear.pos.discount.entity.FranchiseDiscountPolicy;
-import com.unear.pos.discount.repository.FranchiseDiscountPolicyRepository;
+import com.unear.pos.discount.entity.GeneralDiscountPolicy;
+import com.unear.pos.discount.repository.GeneralDiscountPolicyRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-public class FranchiseDiscountPolicyStrategy implements DiscountPolicyStrategy {
+@RequiredArgsConstructor
+public class GeneralDiscountPolicyStrategy implements DiscountPolicyStrategy {
 
-    private final FranchiseDiscountPolicyRepository repository;
+    private final GeneralDiscountPolicyRepository repository;
 
     @Override
-    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long franchiseId,
+    public List<DiscountPolicyInfo> getDiscountPolicies(MembershipGrade memberGrade, Long placeId,
                                                         EventParticipationStatus eventStatus) {
-
-        List<FranchiseDiscountPolicy> allGradePolicies = repository.findByFranchiseIdAndMembershipCode(franchiseId,
+        /**
+         * 1. 전체 등급이 적용 가능한 쿠폰이 존재하는지 조회
+         */
+        List<GeneralDiscountPolicy> allGradePolicies = repository.findByPlaceIdAndMembershipCode(placeId,
                 DiscountTargetGrade.ALL.getCode());
 
+        /**
+         * 2. 특정 등급 정책 조회
+         */
         DiscountTargetGrade targetGrade = DiscountTargetGrade.fromMembershipGrade(memberGrade);
-        List<FranchiseDiscountPolicy> specificGradePolicies = repository.findByFranchiseIdAndMembershipCode(franchiseId,
+        List<GeneralDiscountPolicy> specificGradePolicies = repository.findByPlaceIdAndMembershipCode(placeId,
                 targetGrade.getCode());
 
         return Stream.concat(allGradePolicies.stream(), specificGradePolicies.stream())
@@ -35,4 +40,5 @@ public class FranchiseDiscountPolicyStrategy implements DiscountPolicyStrategy {
                 .map(DiscountPolicyInfo::from)
                 .collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/com/unear/pos/membership/controller/MembershipController.java
+++ b/src/main/java/com/unear/pos/membership/controller/MembershipController.java
@@ -6,6 +6,7 @@ import com.unear.pos.common.response.ApiResponse;
 import com.unear.pos.member.dto.MemberInfo;
 import com.unear.pos.membership.dto.MemberVerifyRequestDto;
 import com.unear.pos.membership.service.MembershipService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,9 +27,10 @@ public class MembershipController {
     @PostMapping("/verify")
     public ResponseEntity<ApiResponse<MemberInfo>> verifyMember(
             @Valid @RequestBody MemberVerifyRequestDto request,
-            @CurrentPosSession PosSessionInfo posInfo) {
+            @CurrentPosSession PosSessionInfo posInfo,
+            HttpSession session) {
 
-        MemberInfo memberInfo = membershipService.verifyMember(request, posInfo);
+        MemberInfo memberInfo = membershipService.verifyMember(request, posInfo, session);
         return ResponseEntity.ok(ApiResponse.success("회원 인증 완료", memberInfo));
     }
 }

--- a/src/main/java/com/unear/pos/membership/service/MembershipService.java
+++ b/src/main/java/com/unear/pos/membership/service/MembershipService.java
@@ -3,7 +3,8 @@ package com.unear.pos.membership.service;
 import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.member.dto.MemberInfo;
 import com.unear.pos.membership.dto.MemberVerifyRequestDto;
+import jakarta.servlet.http.HttpSession;
 
 public interface MembershipService {
-    MemberInfo verifyMember(MemberVerifyRequestDto request, PosSessionInfo posInfo);
+    MemberInfo verifyMember(MemberVerifyRequestDto request, PosSessionInfo posInfo, HttpSession session);
 }

--- a/src/main/java/com/unear/pos/membership/service/impl/MembershipServiceImpl.java
+++ b/src/main/java/com/unear/pos/membership/service/impl/MembershipServiceImpl.java
@@ -1,5 +1,6 @@
 package com.unear.pos.membership.service.impl;
 
+import com.unear.pos.common.dto.MemberSession;
 import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.common.dto.enums.VerificationType;
 import com.unear.pos.common.exception.business.MemberNotFoundException;
@@ -10,6 +11,7 @@ import com.unear.pos.member.entity.Member;
 import com.unear.pos.membership.dto.MemberVerifyRequestDto;
 import com.unear.pos.membership.repository.MemberRepository;
 import com.unear.pos.membership.service.MembershipService;
+import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +25,7 @@ public class MembershipServiceImpl implements MembershipService {
 
 
     @Override
-    public MemberInfo verifyMember(MemberVerifyRequestDto request, PosSessionInfo posInfo) {
+    public MemberInfo verifyMember(MemberVerifyRequestDto request, PosSessionInfo posInfo, HttpSession session) {
         VerificationType type = VerificationType.fromString(request.getType());
 
         Member member = switch (type) {
@@ -32,6 +34,9 @@ public class MembershipServiceImpl implements MembershipService {
         };
 
         MemberInfo memberInfo = MemberInfo.from(member);
+
+        MemberSession memberSession = MemberSession.from(memberInfo, posInfo);
+        session.setAttribute("memberSession", memberSession);
 
         List<DiscountPolicyInfo> policies = discountService.getDiscountPolicies(memberInfo.getMemberGrade(), posInfo);
 

--- a/src/test/java/com/unear/pos/discount/strategy/calculator/MembershipUnitDiscountStrategyTest.java
+++ b/src/test/java/com/unear/pos/discount/strategy/calculator/MembershipUnitDiscountStrategyTest.java
@@ -1,0 +1,62 @@
+package com.unear.pos.discount.strategy.calculator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.unear.pos.common.dto.Money;
+import com.unear.pos.discount.dto.DiscountPolicyInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+class MembershipUnitDiscountStrategyTest {
+
+    private MembershipUnitDiscountStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new MembershipUnitDiscountStrategy();
+    }
+
+    private DiscountPolicyInfo buildPolicy(int unitBaseAmount, Integer maxDiscountAmount) {
+        return DiscountPolicyInfo.builder()
+                .unitBaseAmount(unitBaseAmount)
+                .maxDiscountAmount(maxDiscountAmount)
+                .build();
+    }
+
+    @Test
+    void 구매금액_5500원_단위당_100원_예상_500원() {
+        Money result = strategy.calculateDiscount(
+                Money.of(5500L),
+                buildPolicy(100, null)
+        );
+        assertThat(result).isEqualTo(Money.of(500));
+    }
+
+    @Test
+    void 구매금액_1000원_단위당_100원_예상_100원() {
+        Money result = strategy.calculateDiscount(
+                Money.of(1000L),
+                buildPolicy(100, null)
+        );
+        assertThat(result).isEqualTo(Money.of(100));
+    }
+
+    @Test
+    void 구매금액_999원_단위당_100원_예상_0원() {
+        Money result = strategy.calculateDiscount(
+                Money.of(999L),
+                buildPolicy(100, null)
+        );
+        assertThat(result).isEqualTo(Money.zero());
+    }
+
+    @Test
+    void 구매금액_2001원_단위당_100원_예상_200원() {
+        Money result = strategy.calculateDiscount(
+                Money.of(2001L),
+                buildPolicy(100, null)
+        );
+        assertThat(result).isEqualTo(Money.of(200));
+    }
+}


### PR DESCRIPTION
## PR 목적
회원 인증 후 선택한 할인 정책을 실제 구매 금액에 적용하여 할인 금액과 최종 결제 금액을 계산하는 기능 추가
관련 이슈 : #48 
## 변경 사항

할인 적용 API 추가 (POST /discount/apply)
Money 도메인 객체 및 할인 계산 전략 패턴 구현
회원 세션 관리를 위한 MemberSession 클래스 추가

## 주요 구현 내용

Money 클래스로 BigDecimal 기반 안전한 금액 계산
DiscountCalculationStrategy 인터페이스로 할인 유형별 계산 로직 분리
MembershipUnitDiscountStrategy: 1000원당 N원 할인 계산
MembershipFixedDiscountStrategy: 고정 금액 할인 계산
MemberSession 세션 객체로 회원 인증 상태 관리
할인 정책 ID 검증 및 적용 가능 여부 확인 로직


## 테스트 및 동작 화면 (필요 시 첨부)

 ```shell
SENI 🔑   ~
 curl -X POST http://localhost:8080/auth/login \
  -H "Content-Type: application/json" \
  -c cookies.txt \
  -d '{
    "ownerName": "pos1_18f83ac4",
    "ownerPassword": "pos1_18f83ac4"
  }'
{"status":200,"code":"SUCCESS","message":"login success","data":null}%
 SENI 🔑   ~
 curl -X POST http://localhost:8080/membership/verify \
  -H "Content-Type: application/json" \
  -b cookies.txt \
  -d '{
    "type": "barcode",
    "value": "6634488a32174f68"
  }'
{"status":200,"code":"SUCCESS","message":"회원 인증 완료","data":{"memberId":13,"memberName":"테****자","memberGrade":"VIP","discountPolicies":[{"id":5,"discountCode":"MEMBERSHIP_UNIT","unitBaseAmount":100,"fixedDiscount":null,"discountPercent":null,"minPurchaseAmount":null,"maxDiscountAmount":null,"membershipCode":"VIP"}]}}%
 SENI 🔑   ~
 curl -X POST http://localhost:8080/discount/apply \
  -H "Content-Type: application/json" \
  -b cookies.txt \
  -d '{
    "discountPolicyId": 5,
    "purchaseAmount": 20000
  }'
{"status":200,"code":"SUCCESS","message":"할인 적용 완료","data":{"discountCode":"MEMBERSHIP_UNIT","discountAmount":2000,"finalAmount":18000}}%
 SENI 🔑   ~
```


## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
