### PR TITLE
[WL7-390] 이벤트 제휴처 스탬프 생성 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 
-
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/unear/pos/common/client/ExternalNotificationClient.java
+++ b/src/main/java/com/unear/pos/common/client/ExternalNotificationClient.java
@@ -1,0 +1,30 @@
+package com.unear.pos.common.client;
+
+import com.unear.pos.stamp.dto.StampNotificationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExternalNotificationClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${notification.server.url:http://localhost:9090}")
+    private String notificationServerUrl;
+
+    public void sendStampNotification(StampNotificationDto notification) {
+        try {
+            String url = notificationServerUrl + "/api/notifications/send";
+            restTemplate.postForObject(url, notification, Void.class);
+            log.info("Stamp notification sent to external server for user: {}", notification.getUserId());
+        } catch (Exception e) {
+            log.error("Failed to send stamp notification to external server for user: {}",
+                    notification.getUserId(), e);
+        }
+    }
+}

--- a/src/main/java/com/unear/pos/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/unear/pos/common/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.unear.pos.common.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setConnectionRequestTimeout(3000);
+
+        restTemplate.setRequestFactory(factory);
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/unear/pos/payment/entity/UserHistory.java
+++ b/src/main/java/com/unear/pos/payment/entity/UserHistory.java
@@ -67,4 +67,7 @@ public class UserHistory {
 
     @Column(name = "membership_code")
     private String membershipCode;
+
+    @Column(name = "place_category") // 또는 category_code
+    private String placeCategory;
 }

--- a/src/main/java/com/unear/pos/payment/entity/UserHistory.java
+++ b/src/main/java/com/unear/pos/payment/entity/UserHistory.java
@@ -68,6 +68,6 @@ public class UserHistory {
     @Column(name = "membership_code")
     private String membershipCode;
 
-    @Column(name = "place_category") // 또는 category_code
+    @Column(name = "place_category")
     private String placeCategory;
 }

--- a/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
@@ -76,6 +76,7 @@ public class PaymentServiceImpl implements PaymentService {
                 .paidAt(LocalDate.now())
                 .discountCode(memberSession.getDiscountCode())
                 .membershipCode(memberSession.getMemberGrade().getCode())
+                .placeCategory(posInfo.getPlaceCategory().getCode())
                 .build();
     }
 

--- a/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
@@ -8,16 +8,20 @@ import com.unear.pos.payment.dto.response.PaymentResponseDto;
 import com.unear.pos.payment.entity.UserHistory;
 import com.unear.pos.payment.repository.UserHistoryRepository;
 import com.unear.pos.payment.service.PaymentService;
+import com.unear.pos.stamp.service.StampService;
 import jakarta.servlet.http.HttpSession;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class PaymentServiceImpl implements PaymentService {
 
+    private final StampService stampService;
     private final UserHistoryRepository userHistoryRepository;
     private final MemberSessionUtil memberSessionUtil;
 
@@ -29,6 +33,12 @@ public class PaymentServiceImpl implements PaymentService {
 
         UserHistory userHistory = createUserHistory(memberSession, posInfo, request);
         UserHistory savedHistory = userHistoryRepository.save(userHistory);
+
+        try {
+            stampService.createStampAfterPayment(memberSession, posInfo);
+        } catch (Exception e) {
+            log.error("Failed to create stamp after payment", e);
+        }
 
         memberSessionUtil.clearMemberSession(session);
 

--- a/src/main/java/com/unear/pos/stamp/dto/StampNotificationDto.java
+++ b/src/main/java/com/unear/pos/stamp/dto/StampNotificationDto.java
@@ -1,0 +1,20 @@
+package com.unear.pos.stamp.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class StampNotificationDto {
+    private Long userId;
+    private Long stampId;
+    private String eventName;
+    private String placeName;
+    private String eventCode;
+    private LocalDateTime stampedAt;
+    private String message;
+    private String notificationType;
+}

--- a/src/main/java/com/unear/pos/stamp/entity/EventPlace.java
+++ b/src/main/java/com/unear/pos/stamp/entity/EventPlace.java
@@ -1,0 +1,31 @@
+package com.unear.pos.stamp.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "event_places")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class EventPlace {
+
+    @Id
+    @Column(name = "event_place_id")
+    private Long eventPlaceId;
+
+    @Column(name = "unear_event_id", nullable = false)
+    private Long unearEventId;
+
+    @Column(name = "place_id", nullable = false)
+    private Long placeId;
+
+    @Column(name = "event_code", nullable = false)
+    private String eventCode;
+}

--- a/src/main/java/com/unear/pos/stamp/entity/Stamp.java
+++ b/src/main/java/com/unear/pos/stamp/entity/Stamp.java
@@ -1,0 +1,43 @@
+package com.unear.pos.stamp.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stamps")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Stamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stamp_id")
+    private Long stampId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "event_place_id", nullable = false)
+    private Long eventPlaceId;
+
+    @Column(name = "stamped_at", nullable = false)
+    private LocalDateTime stampedAt;
+
+    @Column(name = "event_code", nullable = false)
+    private String eventCode;
+
+    @Column(name = "place_name", nullable = false)
+    private String placeName;
+}

--- a/src/main/java/com/unear/pos/stamp/entity/UnearEvent.java
+++ b/src/main/java/com/unear/pos/stamp/entity/UnearEvent.java
@@ -1,0 +1,55 @@
+package com.unear.pos.stamp.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "unear_events")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UnearEvent {
+
+    @Id
+    @Column(name = "unear_event_id")
+    private Long unearEventId;
+
+    @Column(name = "coupon_template_id")
+    private Long couponTemplateId;
+
+    @Column(name = "event_name", nullable = false)
+    private String eventName;
+
+    @Column(name = "event_description")
+    private String eventDescription;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
+    @Column(name = "radius_meter")
+    private Integer radiusMeter;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDate startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDate endAt;
+
+    @Column(name = "popup_store_id")
+    private Long popupStoreId;
+
+    public boolean isActive() {
+        LocalDate now = LocalDate.now();
+        return !now.isBefore(startAt) && !now.isAfter(endAt);
+    }
+}

--- a/src/main/java/com/unear/pos/stamp/repository/EventPlaceRepository.java
+++ b/src/main/java/com/unear/pos/stamp/repository/EventPlaceRepository.java
@@ -1,0 +1,9 @@
+package com.unear.pos.stamp.repository;
+
+import com.unear.pos.stamp.entity.EventPlace;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventPlaceRepository extends JpaRepository<EventPlace, Long> {
+    Optional<EventPlace> findByPlaceId(Long placeId);
+}

--- a/src/main/java/com/unear/pos/stamp/repository/StampRepository.java
+++ b/src/main/java/com/unear/pos/stamp/repository/StampRepository.java
@@ -1,0 +1,8 @@
+package com.unear.pos.stamp.repository;
+
+import com.unear.pos.stamp.entity.Stamp;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+    boolean existsByUserIdAndEventPlaceId(Long userId, Long eventPlaceId);
+}

--- a/src/main/java/com/unear/pos/stamp/repository/UnearEventRepository.java
+++ b/src/main/java/com/unear/pos/stamp/repository/UnearEventRepository.java
@@ -1,0 +1,15 @@
+package com.unear.pos.stamp.repository;
+
+import com.unear.pos.stamp.entity.UnearEvent;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnearEventRepository extends JpaRepository<UnearEvent, Long> {
+    Optional<UnearEvent> findByStartAtLessThanEqualAndEndAtGreaterThanEqual(LocalDate startDate, LocalDate endDate);
+
+    default Optional<UnearEvent> findActiveEvent() {
+        LocalDate now = LocalDate.now();
+        return findByStartAtLessThanEqualAndEndAtGreaterThanEqual(now, now);
+    }
+}

--- a/src/main/java/com/unear/pos/stamp/service/StampService.java
+++ b/src/main/java/com/unear/pos/stamp/service/StampService.java
@@ -1,0 +1,9 @@
+package com.unear.pos.stamp.service;
+
+import com.unear.pos.common.dto.MemberSession;
+import com.unear.pos.common.dto.PosSessionInfo;
+
+public interface StampService {
+
+    void createStampAfterPayment(MemberSession memberSession, PosSessionInfo posInfo);
+}

--- a/src/main/java/com/unear/pos/stamp/service/impl/StampServiceImpl.java
+++ b/src/main/java/com/unear/pos/stamp/service/impl/StampServiceImpl.java
@@ -1,0 +1,78 @@
+package com.unear.pos.stamp.service.impl;
+
+import com.unear.pos.common.client.ExternalNotificationClient;
+import com.unear.pos.common.dto.MemberSession;
+import com.unear.pos.common.dto.PosSessionInfo;
+import com.unear.pos.common.dto.enums.EventParticipationStatus;
+import com.unear.pos.stamp.dto.StampNotificationDto;
+import com.unear.pos.stamp.entity.EventPlace;
+import com.unear.pos.stamp.entity.Stamp;
+import com.unear.pos.stamp.entity.UnearEvent;
+import com.unear.pos.stamp.repository.EventPlaceRepository;
+import com.unear.pos.stamp.repository.StampRepository;
+import com.unear.pos.stamp.repository.UnearEventRepository;
+import com.unear.pos.stamp.service.StampService;
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StampServiceImpl implements StampService {
+
+    private final StampRepository stampRepository;
+    private final EventPlaceRepository eventPlaceRepository;
+    private final UnearEventRepository unearEventRepository;
+    private final ExternalNotificationClient notificationClient;
+
+    @Override
+    public void createStampAfterPayment(MemberSession memberSession, PosSessionInfo posInfo) {
+        if (posInfo.getEventStatus() == EventParticipationStatus.NONE) {
+            log.debug("Place {} is not participating in events", posInfo.getPlaceId());
+            return;
+        }
+
+        EventPlace eventPlace = eventPlaceRepository.findByPlaceId(posInfo.getPlaceId())
+                .orElseThrow(() -> new IllegalStateException("이벤트 매장 정보를 찾을 수 없습니다"));
+
+        if (stampRepository.existsByUserIdAndEventPlaceId(memberSession.getMemberId(), eventPlace.getEventPlaceId())) {
+            log.info("Stamp already exists for user {} at event place {}",
+                    memberSession.getMemberId(), eventPlace.getEventPlaceId());
+            return;
+        }
+
+        UnearEvent activeEvent = unearEventRepository.findActiveEvent()
+                .orElseThrow(() -> new IllegalStateException("진행중인 이벤트를 찾을 수 없습니다"));
+
+        Stamp stamp = Stamp.builder()
+                .userId(memberSession.getMemberId())
+                .eventPlaceId(eventPlace.getEventPlaceId())
+                .stampedAt(LocalDateTime.now())
+                .eventCode(posInfo.getEventStatus().getCode())
+                .placeName(posInfo.getPlaceName())
+                .build();
+
+        Stamp savedStamp = stampRepository.save(stamp);
+        log.info("Stamp created: {}", savedStamp.getStampId());
+
+        sendStampNotification(savedStamp, activeEvent);
+    }
+
+    private void sendStampNotification(Stamp stamp, UnearEvent event) {
+        StampNotificationDto notification = StampNotificationDto.builder()
+                .userId(stamp.getUserId())
+                .stampId(stamp.getStampId())
+                .eventName(event.getEventName())
+                .placeName(stamp.getPlaceName())
+                .eventCode(stamp.getEventCode())
+                .stampedAt(stamp.getStampedAt())
+                .message(String.format("🎉 %s에서 스탬프를 획득했습니다!", stamp.getPlaceName()))
+                .notificationType("STAMP_CREATED")
+                .build();
+
+        CompletableFuture.runAsync(() -> notificationClient.sendStampNotification(notification));
+    }
+}

--- a/src/main/java/com/unear/pos/stamp/service/impl/StampServiceImpl.java
+++ b/src/main/java/com/unear/pos/stamp/service/impl/StampServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class StampServiceImpl implements StampService {
     private final ExternalNotificationClient notificationClient;
 
     @Override
+    @Transactional
     public void createStampAfterPayment(MemberSession memberSession, PosSessionInfo posInfo) {
         if (posInfo.getEventStatus() == EventParticipationStatus.NONE) {
             log.debug("Place {} is not participating in events", posInfo.getPlaceId());

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,3 +19,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+
+notification:
+  server:
+    url: ${NOTIFICATION_SERVER_URL}


### PR DESCRIPTION
## PR 목적
POS 결제 완료 후 이벤트 참여 매장에서 자동으로 스탬프를 생성하고, 외부 알림 서버를 통해 사용자에게 실시간 알림을 전송하는 기능 추가

## 변경 사항

- 스탬프 생성 로직 추가 (Stamp, EventPlace, UnearEvent 엔티티)
- 외부 알림 서버 연동 클라이언트 구현 (ExternalNotificationClient)
- 결제 서비스에 스탬프 생성 로직 통합

## 주요 구현 내용

- StampService.createStampAfterPayment(): 이벤트 대상 매장 검증 및 스탬프 생성
- ExternalNotificationClient: RestTemplate 기반 외부 알림 서버 HTTP 통신
- 중복 스탬프 방지 로직으로 동일 매장에서 재결제 시 중복 생성 방지
- 비동기 알림 전송으로 결제 트랜잭션과 알림 처리 분리
- 알림 전송 실패가 결제 성공에 영향주지 않도록 예외 격리
- 활성 이벤트 단일 조회로 현재 진행중인 이벤트 기반 스탬프 생성


## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
