### PR TITLE
[WL7-404] 쿠폰 사용 처리 시점을 결제 완료 후로 변경

### DIFF
--- a/src/main/java/com/unear/pos/common/dto/MemberSession.java
+++ b/src/main/java/com/unear/pos/common/dto/MemberSession.java
@@ -21,7 +21,7 @@ public class MemberSession {
     private Long totalDiscountAmount;
     private Long originalAmount;
 
-    private Long userCouponId;   // 추가된 필드
+    private Long userCouponId;
     private String discountCode;
 
     public static MemberSession from(MemberInfo memberInfo, PosSessionInfo posInfo) {
@@ -70,5 +70,9 @@ public class MemberSession {
             total += coupon.getDiscountAmount();
         }
         return total;
+    }
+
+    public boolean hasCouponApplied() {
+        return this.userCouponId != null;
     }
 }

--- a/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
+++ b/src/main/java/com/unear/pos/discount/service/impl/DiscountServiceImpl.java
@@ -103,9 +103,6 @@ public class DiscountServiceImpl implements DiscountService {
         Money discountAmount = discountCalculationService.calculateDiscount(purchaseAmount, policy);
         Money finalAmount = purchaseAmount.subtract(discountAmount);
 
-        userCoupon.markAsUsed();
-        userCouponRepository.save(userCoupon);
-
         DiscountApplyResponseDto responseDto = DiscountApplyResponseDto.builder()
                 .discountCode(policy.getDiscountCode())
                 .discountAmount(discountAmount.getAmount().longValue())

--- a/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -29,6 +30,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final MemberSessionUtil memberSessionUtil;
 
     @Override
+    @Transactional
     public PaymentResponseDto processPayment(PaymentRequestDto request, HttpSession session, PosSessionInfo posInfo) {
         MemberSession memberSession = memberSessionUtil.validateAndGetMemberSession(session);
 

--- a/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/unear/pos/payment/service/impl/PaymentServiceImpl.java
@@ -3,6 +3,8 @@ package com.unear.pos.payment.service.impl;
 import com.unear.pos.common.dto.MemberSession;
 import com.unear.pos.common.dto.PosSessionInfo;
 import com.unear.pos.common.util.MemberSessionUtil;
+import com.unear.pos.coupon.entity.UserCoupon;
+import com.unear.pos.coupon.repository.UserCouponRepository;
 import com.unear.pos.payment.dto.request.PaymentRequestDto;
 import com.unear.pos.payment.dto.response.PaymentResponseDto;
 import com.unear.pos.payment.entity.UserHistory;
@@ -23,6 +25,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     private final StampService stampService;
     private final UserHistoryRepository userHistoryRepository;
+    private final UserCouponRepository userCouponRepository;
     private final MemberSessionUtil memberSessionUtil;
 
     @Override
@@ -34,11 +37,8 @@ public class PaymentServiceImpl implements PaymentService {
         UserHistory userHistory = createUserHistory(memberSession, posInfo, request);
         UserHistory savedHistory = userHistoryRepository.save(userHistory);
 
-        try {
-            stampService.createStampAfterPayment(memberSession, posInfo);
-        } catch (Exception e) {
-            log.error("Failed to create stamp after payment", e);
-        }
+        processCouponAfterPayment(memberSession);
+        stampService.createStampAfterPayment(memberSession, posInfo);
 
         memberSessionUtil.clearMemberSession(session);
 
@@ -111,5 +111,15 @@ public class PaymentServiceImpl implements PaymentService {
     public List<UserHistory> getPlacePaymentHistory(Long placeId) {
         return userHistoryRepository.findByPlaceIdOrderByPaidAtDesc(placeId);
 
+    }
+
+    private void processCouponAfterPayment(MemberSession memberSession) {
+        if (memberSession.hasCouponApplied()) {
+            UserCoupon userCoupon = userCouponRepository.findById(memberSession.getUserCouponId())
+                    .orElseThrow(() -> new IllegalArgumentException("쿠폰을 찾을 수 없습니다"));
+
+            userCoupon.markAsUsed();
+            userCouponRepository.save(userCoupon);
+        }
     }
 }


### PR DESCRIPTION
## 목적
- 쿠폰 적용 단계에서 즉시 사용 처리되던 문제 해결
- 결제 실패/취소 시 쿠폰 손실 방지

## 구현 사항
- applyCouponDiscount에서 쿠폰 사용 처리 로직 제거
- processPayment에 processCouponAfterPayment 메서드 추가
- MemberSession에 hasCouponApplied 도메인 메서드 추가
- 쿠폰 사용 처리를 결제 완료 후 시점으로 이동